### PR TITLE
Update encrypt_key.py to consider environment variables for secret file path

### DIFF
--- a/encrypt_key.py
+++ b/encrypt_key.py
@@ -3,7 +3,10 @@ import sys
 import base64
 from cryptography.fernet import Fernet
 
-def get_secret_key(secret_file_path):
+def get_secret_key(secret_file_path=None):
+  if secret_file_path is None:
+    secret_file_path = os.getenv('SECRET_FILE', '/docker-volume/secret.key')
+    
   if os.path.exists(secret_file_path):
     with open(secret_file_path, 'rb') as f:
       return f.read()
@@ -24,13 +27,12 @@ def decrypt_key(encrypted_api_key, secret_key):
   return decrypted_key.decode()
 
 def main():
-  secret_file_path = os.getenv('SECRET_FILE', '/docker-volume/secret.key')
   if len(sys.argv) != 2:
     print("Usage: encrypt_key.py <api key string>")
     sys.exit(1)
   
   api_key = sys.argv[1]
-  secret_key = get_secret_key(secret_file_path)
+  secret_key = get_secret_key()
   encrypted_api_key = encrypt_key(api_key, secret_key)
   print(encrypted_api_key)
 


### PR DESCRIPTION
Related to #3

Modify `encrypt_key.py` to consider environment variables for the secret file path when `secret_file_path` is `None`.

* Update `get_secret_key` to accept `secret_file_path=None` and determine the path from environment variables and default values.
* Update `main` to call `get_secret_key` with `secret_file_path=None`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ab-ten/safe-proxy-docker/pull/5?shareId=48f115e8-b11a-47f2-937c-3194d15a472e).