### PR TITLE
Change docker network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,16 @@ services:
       - type: tmpfs
         target: /tmpfs
     networks:
-      - openai_api_proxy_default
+      - safe_proxy_docker
     ports:
       - "8931:80"
 
 volumes:
   secret-key-volume:
 
-# run `docker network create openai_api_proxy_default`
+# run `docker network create safe_proxy_docker`
 # before running docker-compose up
 networks:
-  openai_api_proxy_default:
+  safe_proxy_docker:
     external: true
     driver: bridge


### PR DESCRIPTION
Fixes #12

Change the Docker network name from `openai_api_proxy_default` to `safe_proxy_docker`.

* Update `docker-compose.yml` to reference `safe_proxy_docker` in the `networks` section.
* Update the comment in `docker-compose.yml` to instruct to run `docker network create safe_proxy_docker` before running `docker-compose up`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ab-ten/safe-proxy-docker/pull/13?shareId=0bded3f2-ab02-4f3c-84d7-36d3151d762a).