### PR TITLE
Add README files in Japanese and English

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,0 +1,75 @@
+# safe-proxy-docker
+
+[Japanese README](README.md)
+
+## Purpose
+
+The main purpose of this project is to create a secure reverse proxy for multiple API servers using Docker. The proxy replaces client dummy keys with real API keys to ensure secure connections. The project involves setting up configurations, encrypting API keys, and using Nginx for proxy handling.
+
+## Feature Introduction
+
+The key features of this project are:
+
+- **Secure reverse proxy**: The project creates a secure reverse proxy for multiple API servers using Docker, ensuring secure connections by replacing client dummy keys with real API keys.
+- **Configuration-based setup**: The proxy is configured using a `config.yaml` file, which defines the server configurations, including API endpoints and authentication details.
+- **API key encryption**: Real API keys are encrypted and stored in the `config.yaml` file. The project provides utilities for encrypting API keys and setting up the environment.
+- **Nginx with Lua module**: The project uses Nginx with the Lua module to handle proxy requests and authentication, ensuring efficient and secure processing of requests.
+- **SQLite database**: The configurations from `config.yaml` are converted to a SQLite database for efficient access during runtime.
+- **Docker integration**: The project is designed to run within a Docker container, with specific instructions for setting up the Docker environment, including creating a Docker network and using `docker compose` commands.
+- **Environment variables**: The project allows customization of file paths and other settings using environment variables, providing flexibility in deployment.
+- **Secure handling of API keys**: The project ensures secure handling of API keys and configurations within the Docker container, with encrypted keys being decrypted during runtime and stored in a temporary SQLite database.
+- **Utilities for key management**: The project includes utilities like `encrypt_key.py` for encrypting API keys and setting up the environment, making it easier to manage API keys securely.
+
+## Usage
+
+### Step-by-step
+
+1. Ensure you have Docker installed and running on your system.
+2. Create a Docker network named `safe_proxy_docker` by running the command:
+   ```sh
+   docker network create safe_proxy_docker
+   ```
+3. Prepare your real API key that you want to encrypt.
+4. Use the `encrypt_key.py` script to encrypt your real API key. You can do this by running the following command:
+   ```sh
+   docker compose run --rm --entrypoint /usr/local/bin/encrypt_key.py api_proxy YOUR_API_KEY
+   ```
+   Replace `YOUR_API_KEY` with your actual API key. This command will output the encrypted API key.
+5. Copy the encrypted API key and update the `config.yaml` file with the encrypted key. You can use the `config.yaml.sample` as a reference. For example:
+   ```yaml
+   servers:
+     openai:
+       origin: "https://api.openai.com/"
+       authentication:
+         type: "Bearer"
+         keys:
+           "sk-proj-1": "ENCRYPTED_API_KEY"
+   ```
+   Replace `ENCRYPTED_API_KEY` with the encrypted key you obtained in the previous step.
+6. Save the updated `config.yaml` file in the root directory of the project.
+
+### Use `docker compose` command
+
+- Start `safe-proxy-docker` by running `docker compose up -d` or `docker compose up`.
+
+### Usage from other docker containers
+
+- Add a setting to use the `safe_proxy_docker` network.
+- If your program uses OpenAI modules/libraries, set the following environment variables:
+  ```sh
+  export OPENAI_API_BASE=http://api_proxy/openai/v1/
+  export OPENAI_API_KEY=<DUMMY_KEY_AS_YOU_SET>
+  ```
+- Ensure `safe-proxy-docker` is running by executing `docker compose up -d` or `docker compose up`.
+
+### Usage from host environment
+
+- Set the following environment variables, similar to the container case:
+  ```sh
+  export OPENAI_API_BASE=http://127.0.0.1:8931/openai/v1/
+  export OPENAI_API_KEY=<DUMMY_KEY_AS_YOU_SET>
+  ```
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# safe-proxy-docker
+
+[English README](README-en.md)
+
+## 目的
+
+このプロジェクトの主な目的は、Dockerを使用して複数のAPIサーバーのためのセキュアなリバースプロキシを作成することです。プロキシはクライアントのダミーキーをリアルAPIキーに置き換えて、セキュアな接続を確保します。このプロジェクトには、設定のセットアップ、APIキーの暗号化、Nginxを使用したプロキシ処理が含まれます。
+
+## 機能の紹介
+
+このプロジェクトの主な機能は以下の通りです：
+
+- **セキュアなリバースプロキシ**：Dockerを使用して複数のAPIサーバーのためのセキュアなリバースプロキシを作成し、クライアントのダミーキーをリアルAPIキーに置き換えてセキュアな接続を確保します。
+- **設定ベースのセットアップ**：プロキシは`config.yaml`ファイルを使用して設定され、APIエンドポイントや認証の詳細を定義します。
+- **APIキーの暗号化**：リアルAPIキーは暗号化されて`config.yaml`ファイルに保存されます。プロジェクトはAPIキーの暗号化と環境のセットアップのためのユーティリティを提供します。
+- **NginxとLuaモジュール**：プロジェクトはNginxとLuaモジュールを使用してプロキシリクエストと認証を処理し、効率的でセキュアなリクエスト処理を実現します。
+- **SQLiteデータベース**：`config.yaml`の設定はSQLiteデータベースに変換され、ランタイム中の効率的なアクセスを実現します。
+- **Docker統合**：プロジェクトはDockerコンテナ内で実行されるように設計されており、Docker環境のセットアップに関する具体的な指示が含まれています。
+- **環境変数**：プロジェクトは環境変数を使用してファイルパスやその他の設定をカスタマイズでき、デプロイの柔軟性を提供します。
+- **APIキーと設定のセキュアな取り扱い**：プロジェクトはDockerコンテナ内でAPIキーと設定をセキュアに取り扱い、暗号化されたキーをランタイム中に復号して一時的なSQLiteデータベースに保存します。
+- **キー管理のためのユーティリティ**：プロジェクトには`encrypt_key.py`のようなAPIキーの暗号化と環境のセットアップのためのユーティリティが含まれており、APIキーをセキュアに管理しやすくします。
+
+## 使い方
+
+### ステップバイステップで
+
+1. Dockerがシステムにインストールされ、実行されていることを確認します。
+2. 次のコマンドを実行して、`safe_proxy_docker`という名前のDockerネットワークを作成します：
+   ```sh
+   docker network create safe_proxy_docker
+   ```
+3. 暗号化したいリアルAPIキーを準備します。
+4. `encrypt_key.py`スクリプトを使用してリアルAPIキーを暗号化します。次のコマンドを実行します：
+   ```sh
+   docker compose run --rm --entrypoint /usr/local/bin/encrypt_key.py api_proxy YOUR_API_KEY
+   ```
+   `YOUR_API_KEY`を実際のAPIキーに置き換えます。このコマンドは暗号化されたAPIキーを出力します。
+5. 暗号化されたAPIキーをコピーし、`config.yaml`ファイルに更新します。`config.yaml.sample`を参考にします。例えば：
+   ```yaml
+   servers:
+     openai:
+       origin: "https://api.openai.com/"
+       authentication:
+         type: "Bearer"
+         keys:
+           "sk-proj-1": "ENCRYPTED_API_KEY"
+   ```
+   `ENCRYPTED_API_KEY`を前のステップで取得した暗号化キーに置き換えます。
+6. 更新された`config.yaml`ファイルをプロジェクトのルートディレクトリに保存します。
+
+### `docker compose`コマンドの使用
+
+- `docker compose up -d`もしくは`docker compose up`で`safe-proxy-docker`を起動します。
+
+### 他のDockerコンテナからの使い方
+
+- `safe_proxy_docker`ネットワークを使用する設定を追加します。
+- OpenAIのモジュール/ライブラリを使用しているプログラムの場合は次の環境変数を設定します：
+  ```sh
+  export OPENAI_API_BASE=http://api_proxy/openai/v1/
+  export OPENAI_API_KEY=<DUMMY_KEY_AS_YOU_SET>
+  ```
+- `docker compose up -d`もしくは`docker compose up`で`safe-proxy-docker`を起動しておきます。
+
+### ホスト環境からの使い方
+
+- コンテナの場合と同様に次の環境変数を設定します：
+  ```sh
+  export OPENAI_API_BASE=http://127.0.0.1:8931/openai/v1/
+  export OPENAI_API_KEY=<DUMMY_KEY_AS_YOU_SET>
+  ```
+
+## ライセンス
+
+このプロジェクトは[MITライセンス](LICENSE)の下でライセンスされています。


### PR DESCRIPTION
Fixes #11

Add README.md and README-en.md files to the repository.

* **README.md**: 
  - Create a Japanese README file with sections for purpose, feature introduction, usage, and license.
  - Include a link to the English README at the beginning.
  - Provide detailed steps for creating the encrypted real API key, setting up Docker network, and using `docker compose` command.
  - Explain usage from other Docker containers and host environment.

* **README-en.md**: 
  - Create an English README file with sections for purpose, feature introduction, usage, and license.
  - Include a link to the Japanese README at the beginning.
  - Provide detailed steps for creating the encrypted real API key, setting up Docker network, and using `docker compose` command.
  - Explain usage from other Docker containers and host environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ab-ten/safe-proxy-docker/pull/14?shareId=5da4a8e2-1e75-487f-9b00-5cd2518f15d2).