### PR TITLE
Add VERSION file and display version on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip \
 
 COPY --chmod=755 *.py *.sh /usr/local/bin/
 COPY --chmod=644 nginx.conf /etc/nginx/nginx.conf
+COPY VERSION /app/VERSION
 
 RUN mkdir -p /docker-volume /tmpfs
 

--- a/ImplementationSpec.md
+++ b/ImplementationSpec.md
@@ -120,3 +120,26 @@ Dockerfile の起動シェルスクリプトから呼び出され、以下の処
   - /app: ホストのプロジェクトトップディレクトリ
   - /tmpfs: tmpfs マウントポイント
   - /docker-volume: docker volume マウントポイント
+
+## VERSION ファイルについて
+
+プロジェクトには `VERSION` ファイルが含まれており、現在のバージョン番号が記載されています。
+
+### VERSION ファイルの構造
+
+`VERSION` ファイルは以下のような構造を持ちます：
+
+```
+0.1.0
+# This file contains the version number of the project.
+# The first line represents the current version.
+# Subsequent lines are comments explaining the purpose of the file.
+```
+
+- 最初の行には現在のバージョン番号が記載されています。
+- 2行目以降には、ファイルの目的を説明するコメントが記載されています。
+
+### VERSION ファイルの使用方法
+
+- コンテナ起動時に `VERSION` ファイルの内容が読み込まれ、バージョン情報が表示されます。
+- `entrypoint.sh` スクリプト内で `VERSION` ファイルの内容が読み込まれ、コンテナ起動時にバージョン情報が表示されます。

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,4 @@
+0.1.0
+# This file contains the version number of the project.
+# The first line represents the current version.
+# Subsequent lines are comments explaining the purpose of the file.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Read the VERSION file and store its content in a variable
+VERSION=$(head -n 1 /app/VERSION)
+
+# Display the version information when the container starts
+echo "safe-proxy-docker version $VERSION"
+
 # secret を作成（初回起動時のみ）
 python /usr/local/bin/encrypt_key.py DUMMY > /dev/null
 


### PR DESCRIPTION
Fixes #21

Add versioning to the project by including a `VERSION` file and displaying the version on container startup.

* **VERSION File:**
  - Add a `VERSION` file with the version number 0.1.0 on the first line.
  - Include comments on subsequent lines explaining the purpose of the file.

* **Entrypoint Script:**
  - Modify `entrypoint.sh` to read the `VERSION` file and store its content in a variable.
  - Display the version information when the container starts.

* **Dockerfile:**
  - Copy the `VERSION` file to the container.

* **Documentation:**
  - Update `ImplementationSpec.md` to include an explanation about the `VERSION` file and its usage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ab-ten/safe-proxy-docker/pull/22?shareId=5f9255dd-ba02-473c-93b7-ffbad69a71b4).