### PR TITLE
Update README.md with docker compose build instructions

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -22,20 +22,24 @@ The key features of this project are:
 
 ## Usage
 
-### Step-by-step
+### Setup
 
 1. Ensure you have Docker installed and running on your system.
 2. Create a Docker network named `safe_proxy_docker` by running the command:
    ```sh
    docker network create safe_proxy_docker
    ```
-3. Prepare your real API key that you want to encrypt.
-4. Use the `encrypt_key.py` script to encrypt your real API key. You can do this by running the following command:
+3. Run `docker compose build` to build the project:
+   ```sh
+   docker compose build
+   ```
+4. Prepare your real API key that you want to encrypt.
+5. Use the `encrypt_key.py` script to encrypt your real API key. You can do this by running the following command:
    ```sh
    docker compose run --rm --entrypoint /usr/local/bin/encrypt_key.py api_proxy YOUR_API_KEY
    ```
    Replace `YOUR_API_KEY` with your actual API key. This command will output the encrypted API key.
-5. Copy the encrypted API key and update the `config.yaml` file with the encrypted key. You can use the `config.yaml.sample` as a reference. For example:
+6. Copy the encrypted API key and update the `config.yaml` file with the encrypted key. You can use the `config.yaml.sample` as a reference. For example:
    ```yaml
    servers:
      openai:
@@ -46,8 +50,8 @@ The key features of this project are:
            "sk-proj-1": "ENCRYPTED_API_KEY"
    ```
    Replace `ENCRYPTED_API_KEY` with the encrypted key you obtained in the previous step.
-6. Save the updated `config.yaml` file in the root directory of the project.
-7. Copy the `.env.sample` file to `.env` and edit it if necessary. For example, to change the host machine port, set the `HOST_PORT`:
+7. Save the updated `config.yaml` file in the root directory of the project.
+8. Copy the `.env.sample` file to `.env` and edit it if necessary. For example, to change the host machine port, set the `HOST_PORT`:
    ```sh
    cp .env.sample .env
    ```
@@ -55,7 +59,23 @@ The key features of this project are:
 
 ### Use `docker compose` command
 
-- Start `safe-proxy-docker` by running `docker compose up -d` or `docker compose up`.
+- Start `safe-proxy-docker` by running `docker compose up -d` or `docker compose up`. After setup, you can start it with only `docker compose up [-d]`.
+
+### Update Procedure
+
+- To update the project, run the following commands:
+  ```sh
+  git pull
+  docker compose build
+  ```
+
+### Procedure when changing `config.yaml`
+
+- If you change `config.yaml`, you need to restart the Docker container. Run the following commands:
+  ```sh
+  docker compose down
+  docker compose up -d
+  ```
 
 ### Usage from other docker containers
 

--- a/README.md
+++ b/README.md
@@ -22,20 +22,24 @@
 
 ## 使い方
 
-### ステップバイステップで
+### セットアップ
 
 1. Dockerがシステムにインストールされ、実行されていることを確認します。
 2. 次のコマンドを実行して、`safe_proxy_docker`という名前のDockerネットワークを作成します：
    ```sh
    docker network create safe_proxy_docker
    ```
-3. 暗号化したいリアルAPIキーを準備します。
-4. `encrypt_key.py`スクリプトを使用してリアルAPIキーを暗号化します。次のコマンドを実行します：
+3. `docker compose build`を実行してプロジェクトをビルドします：
+   ```sh
+   docker compose build
+   ```
+4. 暗号化したいリアルAPIキーを準備します。
+5. `encrypt_key.py`スクリプトを使用してリアルAPIキーを暗号化します。次のコマンドを実行します：
    ```sh
    docker compose run --rm --entrypoint /usr/local/bin/encrypt_key.py api_proxy YOUR_API_KEY
    ```
    `YOUR_API_KEY`を実際のAPIキーに置き換えます。このコマンドは暗号化されたAPIキーを出力します。
-5. 暗号化されたAPIキーをコピーし、`config.yaml`ファイルに更新します。`config.yaml.sample`を参考にします。例えば：
+6. 暗号化されたAPIキーをコピーし、`config.yaml`ファイルに更新します。`config.yaml.sample`を参考にします。例えば：
    ```yaml
    servers:
      openai:
@@ -46,8 +50,8 @@
            "sk-proj-1": "ENCRYPTED_API_KEY"
    ```
    `ENCRYPTED_API_KEY`を前のステップで取得した暗号化キーに置き換えます。
-6. 更新された`config.yaml`ファイルをプロジェクトのルートディレクトリに保存します。
-7. `.env.sample`ファイルを`.env`ファイルにコピーし、必要に応じて編集します。例えば、ホストマシンのポートを変更する場合は、`HOST_PORT`を設定します。
+7. 更新された`config.yaml`ファイルをプロジェクトのルートディレクトリに保存します。
+8. `.env.sample`ファイルを`.env`ファイルにコピーし、必要に応じて編集します。例えば、ホストマシンのポートを変更する場合は、`HOST_PORT`を設定します。
    ```sh
    cp .env.sample .env
    ```
@@ -55,7 +59,23 @@
 
 ### `docker compose`コマンドの使用
 
-- `docker compose up -d`もしくは`docker compose up`で`safe-proxy-docker`を起動します。
+- `docker compose up -d`もしくは`docker compose up`で`safe-proxy-docker`を起動します。セットアップ完了後は、`docker compose up [-d]`のみで起動できます。
+
+### 更新手順
+
+- プロジェクトを更新するには、次のコマンドを実行します：
+  ```sh
+  git pull
+  docker compose build
+  ```
+
+### `config.yaml`を変更した場合の手順
+
+- `config.yaml`を変更した場合、Dockerコンテナを再起動する必要があります。次のコマンドを実行します：
+  ```sh
+  docker compose down
+  docker compose up -d
+  ```
 
 ### 他のDockerコンテナからの使い方
 

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-0.1.0
+0.1.1
 # This file contains the version number of the project.
 # The first line represents the current version.
 # Subsequent lines are comments explaining the purpose of the file.


### PR DESCRIPTION
Fixes #23

Add instructions for using `docker compose build` and updating the project in `README.md` and `README-en.md`.

* **README.md**
  - Add instructions to run `docker compose build` after creating the Docker network.
  - Change "ステップバイステップで" to "セットアップ" and mention that after setup, only `docker compose up [-d]` is needed to start.
  - Add instructions for updating with `git pull` and `docker compose build`.
  - Add instructions to restart Docker container after changing `config.yaml`.

* **README-en.md**
  - Sync content with changes made to `README.md`.

* **VERSION**
  - Increment patch version by 1.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ab-ten/safe-proxy-docker/pull/24?shareId=9d8a7764-f05b-432f-834e-ac7c7ad9ed76).